### PR TITLE
Added cross-build for Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: scala
-scala: 2.12.10
+
+scala:
+  - 2.13.1
+  - 2.12.10
+
 jdk: openjdk8
 
 dist: trusty
 sudo: required
-
-stages:
-  - name: test
-  - name: publish
-    if: NOT type = pull_request
 
 cache:
   directories:
@@ -34,24 +33,20 @@ install:
   - $SBT transferCommonResources
   - scripts/commonSetup
 
-jobs:
-  include:
-    - stage: test
-      script:
-        - set -e
-        - $SBT ++$TRAVIS_SCALA_VERSION test
+script:
+  - set -e
+  - $SBT ++$TRAVIS_SCALA_VERSION test
 
-    - stage: publish
-      env:
-      script:
-        - set -e
-        - scripts/qdataPublishAndTag
+  - |-
+    if [[ "$TRAVIS_SCALA_VERSION" =~ 2.12 ]]; then
+      if [ $TRAVIS_PULL_REQUEST == "false" ] && [[ "$TRAVIS_BRANCH" =~ backport/v.*|master ]]; then
+        TRAVIS_JOB_NUMBER=1 scripts/qdataPublishAndTag
+      fi
 
-      git:
-        depth: false
+      scripts/checkAndAutoMerge
+    fi
 
 after_success:
-  - scripts/checkAndAutoMerge
   - scripts/discordTravisPost success https://discordapp.com/api/webhooks/$DISCORD_WEBHOOK_TOKENS
 
 after_failure:

--- a/core/src/main/scala/qdata/Codec.scala
+++ b/core/src/main/scala/qdata/Codec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/qdata/QData.scala
+++ b/core/src/main/scala/qdata/QData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/qdata/QDataDecode.scala
+++ b/core/src/main/scala/qdata/QDataDecode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/qdata/QDataEncode.scala
+++ b/core/src/main/scala/qdata/QDataEncode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/qdata/QType.scala
+++ b/core/src/main/scala/qdata/QType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/qdata/Version.scala
+++ b/core/src/main/scala/qdata/Version.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/qdata/CodecSpec.scala
+++ b/core/src/test/scala/qdata/CodecSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,8 +120,11 @@ object CodecSpec extends SpecLike with ScalaCheck {
   def roundtrip[A](codec: Codec[A], value: A) = {
     val encoded = codec.encode(value)
     encoded.isSuccessful must_=== true
-    val Attempt.Successful(DecodeResult(decoded, remainder)) = codec.decode(encoded.require)
-    remainder must_=== BitVector.empty
-    decoded must_=== value
+
+    codec.decode(encoded.require) must beLike {
+      case Attempt.Successful(DecodeResult(decoded, remainder)) =>
+        remainder must_=== BitVector.empty
+        decoded must_=== value
+    }
   }
 }

--- a/core/src/test/scala/qdata/QDataRoundtrip.scala
+++ b/core/src/test/scala/qdata/QDataRoundtrip.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/qdata/QDataSpec.scala
+++ b/core/src/test/scala/qdata/QDataSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/qdata/QDataTestDataSpec.scala
+++ b/core/src/test/scala/qdata/QDataTestDataSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/qdata/TestData.scala
+++ b/core/src/test/scala/qdata/TestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/qdata/TestDataGenerators.scala
+++ b/core/src/test/scala/qdata/TestDataGenerators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json/src/main/scala/qdata/json/ArrayContext.scala
+++ b/json/src/main/scala/qdata/json/ArrayContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json/src/main/scala/qdata/json/NumericParser.scala
+++ b/json/src/main/scala/qdata/json/NumericParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json/src/main/scala/qdata/json/ObjectContext.scala
+++ b/json/src/main/scala/qdata/json/ObjectContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json/src/main/scala/qdata/json/PreciseKeys.scala
+++ b/json/src/main/scala/qdata/json/PreciseKeys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json/src/main/scala/qdata/json/PreciseObjectContext.scala
+++ b/json/src/main/scala/qdata/json/PreciseObjectContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json/src/main/scala/qdata/json/PreciseParser.scala
+++ b/json/src/main/scala/qdata/json/PreciseParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json/src/main/scala/qdata/json/QDataFacade.scala
+++ b/json/src/main/scala/qdata/json/QDataFacade.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json/src/test/scala/qdata/json/NumericRewrite.scala
+++ b/json/src/test/scala/qdata/json/NumericRewrite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json/src/test/scala/qdata/json/QDataFacadeSpec.scala
+++ b/json/src/test/scala/qdata/json/QDataFacadeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json/src/test/scala/qdata/json/QDataPreciseFacadeSpec.scala
+++ b/json/src/test/scala/qdata/json/QDataPreciseFacadeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json/src/test/scala/qdata/json/TestDataRender.scala
+++ b/json/src/test/scala/qdata/json/TestDataRender.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,11 +3,11 @@ package qdata.project
 import sbt._
 
 object Dependencies {
-  private val predefVersion     = "0.0.7"
+  private val predefVersion     = "0.1.0"
   private val scalazVersion     = "7.2.30"
   private val scalacheckVersion = "1.14.3"
   private val scodecVersion     = "1.11.4"
-  private val spireVersion      = "0.16.2"
+  private val spireVersion      = "0.17.0-M1"
   private val specsVersion      = "4.8.1"
   private val jawnVersion       = "0.14.3"
   private val tectonicVersion   = IO.read(file("./tectonic-version")).trim
@@ -32,6 +32,7 @@ object Dependencies {
   )
 
   def tectonic = Seq(
-    "com.slamdata" %% "tectonic" % tectonicVersion
+    "com.slamdata"           %% "tectonic"                % tectonicVersion,
+    "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.3"
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,4 @@ resolvers += Resolver.bintrayRepo("slamdata-inc", "maven-public")
 
 addSbtPlugin("com.eed3si9n"    % "sbt-assembly"  % "0.14.10")
 addSbtPlugin("com.eed3si9n"    % "sbt-buildinfo" % "0.9.0")
-addSbtPlugin("com.slamdata"    % "sbt-slamdata"  % "5.1.4")
+addSbtPlugin("com.slamdata"    % "sbt-slamdata"  % "5.3.2")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.bintrayRepo("slamdata-inc", "maven-public")
 
-addSbtPlugin("com.slamdata"    % "sbt-slamdata" % "5.1.4")
+addSbtPlugin("com.slamdata"    % "sbt-slamdata" % "5.3.2")

--- a/tectonic/src/main/scala/qdata/tectonic/DriverException.scala
+++ b/tectonic/src/main/scala/qdata/tectonic/DriverException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tectonic/src/main/scala/qdata/tectonic/QDataDriver.scala
+++ b/tectonic/src/main/scala/qdata/tectonic/QDataDriver.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tectonic/src/test/scala/qdata/tectonic/TectonicSupportSpec.scala
+++ b/tectonic/src/test/scala/qdata/tectonic/TectonicSupportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import org.specs2.mutable.SpecLike
 
 import scalaz.std.either._
 import scalaz.std.list._
-import scalaz.std.stream._
 import scalaz.syntax.foldable._
 
 object TectonicSupportSpec extends SpecLike with ScalaCheck {
@@ -44,7 +43,7 @@ object TectonicSupportSpec extends SpecLike with ScalaCheck {
         _Array(xs map normalize)
 
       case _Object(xs) =>
-        _Object(xs mapValues normalize)
+        _Object(xs map { case (k, v) => (k, normalize(v)) })
 
       case _Meta(_Meta(v, mi), mo) =>
         normalize(_Meta(v, _Meta(mi, mo)))
@@ -75,7 +74,7 @@ object TectonicSupportSpec extends SpecLike with ScalaCheck {
     val results =
       normalized
         .grouped(batchSize)
-        .toStream
+        .toList
         .foldMapM(driver.consume(_))
 
     val actual = for {

--- a/time/src/main/scala/qdata/time/DateTimeInterval.scala
+++ b/time/src/main/scala/qdata/time/DateTimeInterval.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,8 @@ import java.time.{
 }
 import scalaz.\/
 import scalaz.Scalaz._
-import slamdata.Predef._
+
+import scala._, Predef._
 
 /**
   * `parse <-> toString` is not an isomorphism, because the first

--- a/time/src/main/scala/qdata/time/OffsetDate.scala
+++ b/time/src/main/scala/qdata/time/OffsetDate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/time/src/test/scala/qdata/time/DateTimeIntervalSpec.scala
+++ b/time/src/test/scala/qdata/time/DateTimeIntervalSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/time/src/test/scala/qdata/time/TimeGenerators.scala
+++ b/time/src/test/scala/qdata/time/TimeGenerators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014–2019 SlamData Inc.
+ * Copyright 2014–2020 SlamData Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Breaking because I had to change some type signatures in `QDataPlate`, as well as upgrade Spire to 0.17.0-M1.